### PR TITLE
Reacting to name change of Czechia

### DIFF
--- a/src/country/iso_erlang_country_converter.erl
+++ b/src/country/iso_erlang_country_converter.erl
@@ -593,7 +593,7 @@ alpha_2_to_name_upper(<<"CV">>) -> <<"Cape Verde"/utf8>>;
 alpha_2_to_name_upper(<<"CW">>) -> <<"Curaçao"/utf8>>;
 alpha_2_to_name_upper(<<"CX">>) -> <<"Christmas Island"/utf8>>;
 alpha_2_to_name_upper(<<"CY">>) -> <<"Cyprus"/utf8>>;
-alpha_2_to_name_upper(<<"CZ">>) -> <<"Czech Republic"/utf8>>;
+alpha_2_to_name_upper(<<"CZ">>) -> <<"Czechia"/utf8>>;
 alpha_2_to_name_upper(<<"DE">>) -> <<"Germany"/utf8>>;
 alpha_2_to_name_upper(<<"DJ">>) -> <<"Djibouti"/utf8>>;
 alpha_2_to_name_upper(<<"DK">>) -> <<"Denmark"/utf8>>;
@@ -849,7 +849,7 @@ alpha_3_to_name_upper(<<"CUW">>) -> <<"Curaçao"/utf8>>;
 alpha_3_to_name_upper(<<"CXR">>) -> <<"Christmas Island"/utf8>>;
 alpha_3_to_name_upper(<<"CYM">>) -> <<"Cayman Islands"/utf8>>;
 alpha_3_to_name_upper(<<"CYP">>) -> <<"Cyprus"/utf8>>;
-alpha_3_to_name_upper(<<"CZE">>) -> <<"Czech Republic"/utf8>>;
+alpha_3_to_name_upper(<<"CZE">>) -> <<"Czechia"/utf8>>;
 alpha_3_to_name_upper(<<"DEU">>) -> <<"Germany"/utf8>>;
 alpha_3_to_name_upper(<<"DJI">>) -> <<"Djibouti"/utf8>>;
 alpha_3_to_name_upper(<<"DMA">>) -> <<"Dominica"/utf8>>;
@@ -1546,7 +1546,3 @@ alpha_2_to_numerical_code_upper(<<"YT">>) -> 175;
 alpha_2_to_numerical_code_upper(<<"ZA">>) -> 710;
 alpha_2_to_numerical_code_upper(<<"ZM">>) -> 894;
 alpha_2_to_numerical_code_upper(<<"ZW">>) -> 716.
-
-
-
-

--- a/src/country/iso_erlang_country_lists.erl
+++ b/src/country/iso_erlang_country_lists.erl
@@ -572,7 +572,7 @@ get_country_name_list() ->
      <<"Cuba"/utf8>>,
      <<"Curaçao"/utf8>>,
      <<"Cyprus"/utf8>>,
-     <<"Czech Republic"/utf8>>,
+     <<"Czechia"/utf8>>,
      <<"Côte d'Ivoire"/utf8>>,
      <<"Democratic People's Republic of Korea"/utf8>>,
      <<"Congo, the Democratic Republic of the"/utf8>>,


### PR DESCRIPTION
Recently Czech Republic was renamed to Czechia. This is reacting to that name change. See https://www.iso.org/obp/ui/#iso:code:3166:CZ for the new name.